### PR TITLE
Fix testcode 03) テストコード修正

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    title { 'Task' }
+    sequence(:title) { |n| "title#{n}" }
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")
     deadline { Random.rand(from..to) }
+
+    trait :done do
+      status { 2 }
+    end
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     deadline { Random.rand(from..to) }
 
     trait :done do
-      status { 2 }
+      status { :done }
     end
     
     association :project, factory: :project

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -9,5 +9,7 @@ FactoryBot.define do
     trait :done do
       status { 2 }
     end
+    
+    association :project, factory: :project
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :task do
-    sequence(:title) { |n| "title#{n}" }
+    title { 'Task' }
     status { rand(2) }
     from = Date.parse("2019/08/01")
     to   = Date.parse("2019/12/31")

--- a/spec/support/driver_setting.rb
+++ b/spec/support/driver_setting.rb
@@ -1,7 +1,7 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    # driven_by(:rack_test)
-    # driven_by(:selenium_chrome)
-    driven_by(:selenium_chrome_headless)
+    driven_by(:rack_test)
+    driven_by(:selenium_chrome)
+    # driven_by(:selenium_chrome_headless)
   end
 end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe 'Task', type: :system do
+  # == let!で前処理化==
+  let!(:project){ FactoryBot.create(:project) }
+  let!(:task){ FactoryBot.create(:task, project_id: project.id) }
+  # ===
   describe 'Task一覧' do
     context '正常系' do
       it '一覧ページにアクセスした場合、Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
         expect(page).to have_content task.title
         expect(Task.count).to eq 1
@@ -15,8 +17,6 @@ RSpec.describe 'Task', type: :system do
       
       it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_path(project)
         sleep 3
         click_on "View Todos"
@@ -44,14 +44,16 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが新規作成されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
         visit project_tasks_path(project)
         click_link 'New Task'
         fill_in 'Title', with: 'test'
         click_button 'Create Task'
         expect(page).to have_content('Task was successfully created.')
-        expect(Task.count).to eq 1
-        expect(current_path).to eq '/projects/1/tasks/1'
+        expect(Task.count).to eq 2
+        # == let!の前処理でtaskレコード予め1つあり＋１つ新規作成で2個になる ==
+        expect(current_path).to eq '/projects/1/tasks/2'
+        # == 詳細画面のtask_idを修正 ==
+        # == id:1 → id:2 ==
       end
     end
   end
@@ -60,8 +62,6 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskが表示されること' do
         # TODO: ローカル変数ではなく let を使用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit project_task_path(project, task)
         expect(page).to have_content(task.title)
         expect(page).to have_content(task.status)
@@ -75,8 +75,6 @@ RSpec.describe 'Task', type: :system do
     context '正常系' do
       it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
         sleep 3
         fill_in 'Deadline', with: Time.current
@@ -101,14 +99,15 @@ RSpec.describe 'Task', type: :system do
         expect(page).to have_content(Time.current.strftime('%Y-%m-%d'))
         expect(current_path).to eq project_task_path(project, task)
       end
-
+      
+      let!(:task) { create(:task, :done, project_id: project.id) }
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id, status: :done, completion_date: Time.current.yesterday)
         visit edit_project_task_path(project, task)
+        sleep 2
         select 'todo', from: 'Status'
         click_button 'Update Task'
+        sleep 2
         expect(page).to have_content('todo')
         expect(page).not_to have_content(Time.current.strftime('%Y-%m-%d'))
         expect(current_path).to eq project_task_path(project, task)
@@ -119,9 +118,7 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      fit 'Taskが削除されること' do
-        project = FactoryBot.create(:project)
-        task = FactoryBot.create(:task, project_id: project.id)
+      it 'Taskが削除されること' do
         visit project_tasks_path(project)
         sleep 2
         click_link 'Destroy'

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -70,15 +70,16 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      include ApplicationHelper
+      fit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
-        visit edit_project_task_path(project, task)
+        visit edit_project_task_path(task, id: 1)
         fill_in 'Deadline', with: Time.current
         click_button 'Update Task'
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%-m/%d %-H:%M'))
+        expect(page).to have_content(short_time(Time.current))
         # == 日付表記の検証部分を修正 ==
-        expect(current_path).to eq project_tasks_path(project)
+        expect(current_path).to eq project_tasks_path(task)
       end
 
       it 'ステータスを完了にした場合、Taskの完了日に今日の日付が登録されること' do
@@ -97,10 +98,8 @@ RSpec.describe 'Task', type: :system do
       it '既にステータスが完了のタスクのステータスを変更した場合、Taskの完了日が更新されないこと' do
         # TODO: FactoryBotのtraitを利用してください
         visit edit_project_task_path(task, id: 1)
-        sleep 3
         select 'todo', from: 'Status'
         click_button 'Update Task'
-        sleep 3
         expect(page).to have_content('todo')
         expect(page).not_to have_content(Time.current.strftime('%Y-%m-%d'))
         expect(current_path).to eq project_task_path(task, id: 1)
@@ -113,7 +112,7 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      fit 'Taskが削除されること' do
+      it 'Taskが削除されること' do
         visit project_tasks_path(task)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe 'Task', type: :system do
         visit project_tasks_path(task)
         click_link 'Destroy'
         page.driver.browser.switch_to.alert.accept
+        expect(page).to have_selector 'table', text: 'Title'
         expect(page).to have_content `Task was successfully destroyed`
         expect{Task.find(1)}.to raise_exception(ActiveRecord::RecordNotFound)
         expect(current_path).to eq project_tasks_path(task)
@@ -118,3 +119,4 @@ RSpec.describe 'Task', type: :system do
     end
   end
 end
+  

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      fit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      it 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
@@ -119,13 +119,21 @@ RSpec.describe 'Task', type: :system do
   describe 'Task削除' do
     context '正常系' do
       # FIXME: テストが失敗するので修正してください
-      xit 'Taskが削除されること' do
+      fit 'Taskが削除されること' do
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
         visit project_tasks_path(project)
+        sleep 2
         click_link 'Destroy'
+        sleep 2
         page.driver.browser.switch_to.alert.accept
-        expect(page).not_to have_content task.title
+        sleep 2
+        # expect(page).not_to have_content task.title
+        # == 「ではない」ことを検証するのは範囲が広すぎる ==
+        # == 特定の文言を対象とするテスト検証に変更 ==
+        # == 削除成功のメッセージと重複（`Title`が含まれている） ==
+        expect(page).not_to have_content task.title 
+        expect(page).to have_content `Task was successfully destroyed`
         expect(Task.count).to eq 0
         expect(current_path).to eq project_tasks_path(project)
       end

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
 
-      xit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      fit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Task', type: :system do
         expect(current_path).to eq project_tasks_path(project)
       end
       
-      fit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
+      it 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
@@ -73,15 +73,20 @@ RSpec.describe 'Task', type: :system do
 
   describe 'Task編集' do
     context '正常系' do
-      xit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
+      fit 'Taskを編集した場合、一覧画面で編集後の内容が表示されること' do
         # FIXME: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
         visit edit_project_task_path(project, task)
+        sleep 3
         fill_in 'Deadline', with: Time.current
+        sleep 2
         click_button 'Update Task'
+        sleep 2
         click_link 'Back'
-        expect(find('.task_list')).to have_content(Time.current.strftime('%Y-%m-%d'))
+        sleep 2
+        expect(find('.task_list')).to have_content(Time.current.strftime('%-m/%d %-H:%M'))
+        # == 日付表記の検証部分を修正 ==
         expect(current_path).to eq project_tasks_path(project)
       end
 

--- a/spec/system/task_spec.rb
+++ b/spec/system/task_spec.rb
@@ -12,16 +12,30 @@ RSpec.describe 'Task', type: :system do
         expect(Task.count).to eq 1
         expect(current_path).to eq project_tasks_path(project)
       end
-
+      
       fit 'Project詳細からTask一覧ページにアクセスした場合、Taskが表示されること' do
         # FIXME: テストが失敗するので修正してください
         project = FactoryBot.create(:project)
         task = FactoryBot.create(:task, project_id: project.id)
         visit project_path(project)
-        click_link 'View Todos'
-        expect(page).to have_content task.title
-        expect(Task.count).to eq 1
-        expect(current_path).to eq project_tasks_path(project)
+        sleep 3
+        click_on "View Todos"
+        sleep 3
+
+        # 最後に開いたタブを指定
+        within_window(windows.last) do
+          expect(page).to have_content task.title
+          expect(Task.count).to eq 1
+          expect(current_path).to eq project_tasks_path(project)
+        end
+
+        # == 修正前では何が起こっているか
+        # expect(page).to have_content project.name
+          # == project詳細ページへアクセスしているためprojectの名前が表示されている ==
+        # expect(Task.count).to eq 1
+        # expect(current_path).to eq project_path(project)
+         # == Task一覧画面を表示すべきところを、project詳細画面へアクセスしている ==
+        # ==
       end
     end
   end


### PR DESCRIPTION
## 修正
### taskファクトリデータの生成
固定値での指定をシンボルの指定に修正
```Ruby
FactoryBot.define do
  factory :task do
  ‥‥
    trait :done do
      #status { 2 }         #==固定値での指定をシンボルによる指定に修正==
      status { :done }
    end     
  end
end
```

### it 'Taskが削除されること'
”Title”の文言が  
・taskレコードのタイトル  
・削除成功のメッセージ  
どちらにも含まれていることが原因  
→検証範囲をページ全体とすると検証範囲外のエラーメッセージの"Title"があるため
　「taskレコードのタイトルがない」という条件で削除成功を検証できない

↓変更

```have_selector```で検証範囲を限定

```
expect(page).to have_selector 'table', text: 'Title'
```